### PR TITLE
Fix an ImportError

### DIFF
--- a/rednose/rednose.py
+++ b/rednose/rednose.py
@@ -91,7 +91,10 @@ class RedNose(nose.plugins.Plugin):
 		return test.shortDescription() or str(test)
 	
 	def prepareTestResult(self, result):
-		import unittest
+		try:
+			from unittest.runner import _WritelnDecorator # Python 2.7
+		except ImportError:
+			from unittest import _WritelnDecorator
 		result.stream = unittest._WritelnDecorator(open(os.devnull, 'w'))
 
 	def beforeTest(self, test):


### PR DESCRIPTION
Hi,

In python 2.7+ there is an ImportError on unittest, when you try to load _WritelnDecorator.

```
File ".../rednose/rednose.py", line 95, in prepareTestResult
    result.stream = unittest._WritelnDecorator(open(os.devnull, 'w'))
AttributeError: 'module' object has no attribute '_WritelnDecorator'
```

I sent a patch with the solution

Thank you!
