### PR TITLE
Don't block other plugings from running their 'report' phase

### DIFF
--- a/rednose.py
+++ b/rednose.py
@@ -192,7 +192,6 @@ class RedNose(nose.plugins.Plugin):
 			self._outln()
 		
 		self._summarize()
-		return False
 	
 	def _summarize(self):
 		"""summarize all tests - the number of failures, errors and successes"""


### PR DESCRIPTION
Many nose plugins incorrectly use report instead of finalized to do their work. From a small sampling of other plugins it seems that continuing after the report method is normal.

this breaks profiler and timing for example.

https://github.com/andymckay/nose-timing/blob/master/timing/plugins.py
http://nose.readthedocs.org/en/latest/plugins/prof.html
